### PR TITLE
Replace GNU with MUSL targets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,22 +17,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
+
+          # GNU Targets
           - os: ubuntu-latest
-            target:
-              x86_64-unknown-linux-gnu
-              # - os: ubuntu-latest
-              #   target: arm-unknown-linux-gnueabihf
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: arm-unknown-linux-gnueabihf
           - os: ubuntu-latest
             target: armv7-unknown-linux-gnueabihf
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
 
+          # MUSL Targets
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: arm-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          
+          # Darwin targets
           - os: macos-11
             target:
               x86_64-apple-darwin
               # - os: macos-11
               #   target: aarch64-apple-darwin
 
+          # Windows targets
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             triplet: x64-windows-static-md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,16 +18,6 @@ jobs:
       matrix:
         include:
 
-          # GNU Targets
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: arm-unknown-linux-gnueabihf
-          - os: ubuntu-latest
-            target: armv7-unknown-linux-gnueabihf
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-
           # MUSL Targets
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,14 +2,110 @@
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main"
 pre-build = ["apt-get update", "apt install -y liblzma-dev protobuf-compiler"]
 
+[target.x86_64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:main"
+pre-build = [
+    "apt-get update",
+    "apt install -y protobuf-compiler pkg-config autoconf automake autopoint",
+    """PKG_CONFIG_ALL_STATIC=1 && \
+    mkdir -p /tmp/rust-libs && \
+    cd /tmp/rust-libs && \
+    git clone https://git.tukaani.org/xz.git && \
+    cd xz && \
+    git checkout v5.4.3 && \
+    CC=x86_64-linux-musl ./autogen.sh --no-po4a --no-doxygen && \
+    CC=x86_64-linux-musl-gcc ./configure --disable-shared --host x86_64-unknown-linux-musl --disable-doc --disable-scripts && \
+    cd src/liblzma/ && \
+    make && \
+    make install && \
+    cd ../../../ && \
+    rm -rf xz""",
+]
+
+
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
-pre-build = ["dpkg --add-architecture arm64","apt-get update", "apt install -y liblzma-dev:arm64 protobuf-compiler"]
+pre-build = [
+    "dpkg --add-architecture arm64",
+    "apt-get update",
+    "apt install -y liblzma-dev:arm64 protobuf-compiler",
+]
+
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"
+pre-build = [
+    "dpkg --add-architecture armhf",
+    "apt-get update",
+    "apt install -y protobuf-compiler pkg-config autoconf automake autopoint libtool m4",
+    """PKG_CONFIG_ALL_STATIC=1 && \
+    mkdir -p /tmp/rust-libs && \
+    cd /tmp/rust-libs && \
+    git clone https://git.tukaani.org/xz.git && \
+    cd xz && \
+    git checkout v5.4.3 && \
+    CC=aarch64-linux-musl ./autogen.sh --no-po4a --no-doxygen && \
+    CC=aarch64-linux-musl-gcc ./configure --disable-shared --host aarch64-unknown-linux-musl --disable-doc --disable-scripts && \
+    cd src/liblzma/ && \
+    make && \
+    make install && \
+    cd ../../../ && \
+    rm -rf xz""",
+]
 
 [target.arm-unknown-linux-gnueabihf]
 image = "ghcr.io/cross-rs/arm-unknown-linux-gnueabihf:main"
-pre-build = ["dpkg --add-architecture armhf","apt-get update", "apt install -y liblzma-dev:armhf protobuf-compiler"]
+pre-build = [
+    "dpkg --add-architecture armhf",
+    "apt-get update",
+    "apt install -y liblzma-dev:armhf protobuf-compiler",
+]
+
+[target.arm-unknown-linux-musleabihf]
+image = "ghcr.io/cross-rs/arm-unknown-linux-musleabihf:main"
+pre-build = [
+    "dpkg --add-architecture armhf",
+    "apt-get update",
+    "apt install -y protobuf-compiler pkg-config autoconf automake autopoint libtool m4",
+    """PKG_CONFIG_ALL_STATIC=1 && \
+    mkdir -p /tmp/rust-libs && \
+    cd /tmp/rust-libs && \
+    git clone https://git.tukaani.org/xz.git && \
+    cd xz && \
+    git checkout v5.4.3 && \
+    CC=arm-linux-musleabihf ./autogen.sh --no-po4a --no-doxygen && \
+    CC=arm-linux-musleabihf-gcc ./configure --disable-shared --host arm-unknown-linux-musleabihf --disable-doc --disable-scripts && \
+    cd src/liblzma/ && \
+    make && \
+    make install && \
+    cd ../../../ && \
+    rm -rf xz""",
+]
 
 [target.armv7-unknown-linux-gnueabihf]
 image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main"
-pre-build = ["dpkg --add-architecture armhf","apt-get update", "apt install -y liblzma-dev:armhf protobuf-compiler"]
+pre-build = [
+    "dpkg --add-architecture armhf",
+    "apt-get update",
+    "apt install -y liblzma-dev:armhf protobuf-compiler",
+]
+
+[target.armv7-unknown-linux-musleabihf]
+image = "ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main"
+pre-build = [
+    "dpkg --add-architecture armhf",
+    "apt-get update",
+    "apt install -y protobuf-compiler pkg-config autoconf automake autopoint libtool m4",
+    """PKG_CONFIG_ALL_STATIC=1 && \
+    mkdir -p /tmp/rust-libs && \
+    cd /tmp/rust-libs && \
+    git clone https://git.tukaani.org/xz.git && \
+    cd xz && \
+    git checkout v5.4.3 && \
+    CC=arm-linux-musleabihf ./autogen.sh --no-po4a --no-doxygen && \
+    CC=arm-linux-musleabihf-gcc ./configure --disable-shared --host armv7-unknown-linux-musleabihf --disable-doc --disable-scripts && \
+    cd src/liblzma/ && \
+    make && \
+    make install && \
+    cd ../../../ && \
+    rm -rf xz""",
+]


### PR DESCRIPTION
- Add `x86_64-unknown-linux-musl` target
- Add `aarch64-unknown-linux-musl` target
- Add `arm-unknown-linux-musleabihf` target
- Add `armv7-unknown-linux-musleabihf` target
- Remove all GNU targets

Fixes #21 