### PR TITLE
README: fixup install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ curl -sS https://raw.githubusercontent.com/crazystylus/otadump/mainline/install.
 Otherwise, using Cargo:
 
 ```sh
-# Needs LZMA and Protobuf libraries installed.
-# - On macOS: brew install protobuf xz
-# - On Debian / Ubuntu: apt install liblzma-dev protobuf-compiler
+# Needs LZMA, Protobuf and pkg-config libraries installed.
+# - On macOS: brew install protobuf xz pkg-config
+# - On Debian / Ubuntu: apt install liblzma-dev protobuf-compiler pkg-config
 cargo install --locked otadump
 ```
 


### PR DESCRIPTION
This fixes the folloeing:

error: failed to run custom build command for `rust-lzma v0.6.0`

Caused by:
  process didn't exit successfully: `/tmp/cargo-installGWTP6l/release/build/rust-lzma-2c2e7d755bae5887/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=LIBLZMA_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  thread 'main' panicked at 'Could not find liblzma using pkg-config: Could not run `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS="1" PKG_CONFIG_ALLOW_SYSTEM_LIBS="1" "pkg-config" "--static" "--libs" "--cflags" "liblzma"`
  The pkg-config command could not be found.

  Most likely, you need to install a pkg-config package for your OS.
  Try `apt install pkg-config`, or `yum install pkg-config`,
  or `pkg install pkg-config`, or `apk add pkgconfig` depending on your distribution.

  If you've already installed it, ensure the pkg-config command is one of the
  directories in the PATH environment variable.