### PR TITLE
Add partition grid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ dependencies = [
  "sha2",
  "sync-unsafe-cell",
  "tempfile",
+ "term_grid",
  "zip",
 ]
 
@@ -943,6 +944,15 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "term_grid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c9eb7705cb3f0fd71d3955b23db6d372142ac139e8c473952c93bf3c3dc4b7"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rust-lzma = { version = "0.6.0", features = ["static"] }
 sha2 = "0.10.6"
 sync-unsafe-cell = "0.1.0"
 tempfile = "3.6.0"
+term_grid = "0.2.0"
 zip = { version = "0.6.6", features = [
     "deflate",
     "bzip2",


### PR DESCRIPTION
- Adds feature to print partition list as a grid which falls back to a list in case only 1 column can fit or if cli is not running in a tty